### PR TITLE
Provide POVSupplier for ManualShooter command

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -154,7 +154,15 @@ public class RobotContainer {
       return Utilities.deadzone(m_operatorJoystick.getRawAxis(RobotMap.JOYSTICK_AXIS.TURRET));
     }, m_turret));
 
-    m_shooter.setDefaultCommand(new ManualShooter(m_operatorJoystick, m_shooter));
+    m_shooter.setDefaultCommand(new ManualShooter(() -> {
+      if (m_operatorJoystick.getPOV() == 0 || m_operatorJoystick.getPOV() == 45 || m_operatorJoystick.getPOV() == 315) {
+        return (m_shooter.getSetpoint() + 50);
+      } else if (m_operatorJoystick.getPOV() == 180 || m_operatorJoystick.getPOV() == 135
+          || m_operatorJoystick.getPOV() == 225) {
+        return (m_shooter.getSetpoint() - 50);
+      }
+      return m_shooter.getSetpoint();
+    }, m_shooter));
   }
 
   /**

--- a/src/main/java/frc/robot/commands/shooter/ManualShooter.java
+++ b/src/main/java/frc/robot/commands/shooter/ManualShooter.java
@@ -16,7 +16,7 @@ import frc.robot.subsystems.Shooter;
 public class ManualShooter extends CommandBase {
 
   private final Shooter m_shooter;
-  private final DoubleSupplier m_POVSupplier;
+  private final DoubleSupplier m_speedSupplier;
 
   /**
    * Sets the setpoint shooter speed manually, and runs the shooter at its resting
@@ -25,9 +25,9 @@ public class ManualShooter extends CommandBase {
    * @param joystick the joystick to use to set the setpoint
    * @param shooter  the shooter to use for this command
    */
-  public ManualShooter(DoubleSupplier POVSupplier, Shooter shooter) {
+  public ManualShooter(DoubleSupplier speedSupplier, Shooter shooter) {
     m_shooter = shooter;
-    m_POVSupplier = POVSupplier;
+    m_speedSupplier = speedSupplier;
     addRequirements(m_shooter);
   }
 
@@ -39,11 +39,6 @@ public class ManualShooter extends CommandBase {
   @Override
   public void execute() {
     m_shooter.set(Constants.Shooter.IDLE_SPEED * Constants.Shooter.VELOCITY_FF); // Run at resting speed
-    if (m_POVSupplier.getAsDouble() == 0 || m_POVSupplier.getAsDouble() == 45 || m_POVSupplier.getAsDouble() == 315) {
-      m_shooter.setSetpoint(m_shooter.getSetpoint() + 50);
-    } else if (m_POVSupplier.getAsDouble() == 180 || m_POVSupplier.getAsDouble() == 135
-        || m_POVSupplier.getAsDouble() == 225) {
-      m_shooter.setSetpoint(m_shooter.getSetpoint() - 50);
-    }
+    m_shooter.setSetpoint(m_speedSupplier.getAsDouble());
   }
 }

--- a/src/main/java/frc/robot/commands/shooter/ManualShooter.java
+++ b/src/main/java/frc/robot/commands/shooter/ManualShooter.java
@@ -7,7 +7,8 @@
 
 package frc.robot.commands.shooter;
 
-import edu.wpi.first.wpilibj.Joystick;
+import java.util.function.DoubleSupplier;
+
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.Constants;
 import frc.robot.subsystems.Shooter;
@@ -15,18 +16,18 @@ import frc.robot.subsystems.Shooter;
 public class ManualShooter extends CommandBase {
 
   private final Shooter m_shooter;
-  private final Joystick m_joystick;
+  private final DoubleSupplier m_POVSupplier;
 
   /**
    * Sets the setpoint shooter speed manually, and runs the shooter at its resting
    * speed
-   * 
+   *
    * @param joystick the joystick to use to set the setpoint
    * @param shooter  the shooter to use for this command
    */
-  public ManualShooter(Joystick joystick, Shooter shooter) {
+  public ManualShooter(DoubleSupplier POVSupplier, Shooter shooter) {
     m_shooter = shooter;
-    m_joystick = joystick;
+    m_POVSupplier = POVSupplier;
     addRequirements(m_shooter);
   }
 
@@ -38,9 +39,10 @@ public class ManualShooter extends CommandBase {
   @Override
   public void execute() {
     m_shooter.set(Constants.Shooter.IDLE_SPEED * Constants.Shooter.VELOCITY_FF); // Run at resting speed
-    if (m_joystick.getPOV() == 0 || m_joystick.getPOV() == 45 || m_joystick.getPOV() == 315) {
+    if (m_POVSupplier.getAsDouble() == 0 || m_POVSupplier.getAsDouble() == 45 || m_POVSupplier.getAsDouble() == 315) {
       m_shooter.setSetpoint(m_shooter.getSetpoint() + 50);
-    } else if (m_joystick.getPOV() == 180 || m_joystick.getPOV() == 135 || m_joystick.getPOV() == 225) {
+    } else if (m_POVSupplier.getAsDouble() == 180 || m_POVSupplier.getAsDouble() == 135
+        || m_POVSupplier.getAsDouble() == 225) {
       m_shooter.setSetpoint(m_shooter.getSetpoint() - 50);
     }
   }

--- a/src/main/java/frc/robot/commands/shooter/ManualShooter.java
+++ b/src/main/java/frc/robot/commands/shooter/ManualShooter.java
@@ -22,8 +22,8 @@ public class ManualShooter extends CommandBase {
    * Sets the setpoint shooter speed manually, and runs the shooter at its resting
    * speed
    *
-   * @param joystick the joystick to use to set the setpoint
-   * @param shooter  the shooter to use for this command
+   * @param speedSuplier the speed to run the shooter
+   * @param shooter      the shooter to use for this command
    */
   public ManualShooter(DoubleSupplier speedSupplier, Shooter shooter) {
     m_shooter = shooter;


### PR DESCRIPTION
Fix #75 

Rather than passing a joystick in the ctor, pass a POVSupplier.

