### PR TITLE
Set hood and shooter speed command #82

### DIFF
--- a/src/main/java/frc/robot/commands/hood/SetHoodAngle.java
+++ b/src/main/java/frc/robot/commands/hood/SetHoodAngle.java
@@ -10,15 +10,15 @@ package frc.robot.commands.hood;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.Hood;
 
-public class SetHoodSpeed extends CommandBase {
+public class SetHoodAngle extends CommandBase {
   private final Hood m_hood;
   private final double m_speed;
 
   /**
-   * Creates a new SetHoodSpeed.
+   * Creates a new SetHoodAngle command.
    */
 
-  public SetHoodSpeed(double speed, Hood hood) {
+  public SetHoodAngle(double speed, Hood hood) {
     m_speed = speed;
     m_hood = hood;
   }
@@ -26,6 +26,7 @@ public class SetHoodSpeed extends CommandBase {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
+    m_hood.disable();
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/commands/hood/SetHoodSpeed.java
+++ b/src/main/java/frc/robot/commands/hood/SetHoodSpeed.java
@@ -1,0 +1,47 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands.hood;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.Hood;
+
+public class SetHoodSpeed extends CommandBase {
+  private final Hood m_hood;
+  private final double m_speed;
+
+  /**
+   * Creates a new SetHoodSpeed.
+   */
+
+  public SetHoodSpeed(double speed, Hood hood) {
+    m_speed = speed;
+    m_hood = hood;
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    m_hood.setSetpoint(m_speed);
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/shooter/SetShooterSpeed.java
+++ b/src/main/java/frc/robot/commands/shooter/SetShooterSpeed.java
@@ -15,16 +15,18 @@ public class SetShooterSpeed extends CommandBase {
   private final double m_speed;
 
   /**
-   * Creates a new SetShooterSpeed.
+   * Creates a new SetShooterSpeed command.
    */
   public SetShooterSpeed(Shooter shooter, double speed) {
     m_shooter = shooter;
     m_speed = speed;
+    addRequirements(m_shooter);
   }
 
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
+    m_shooter.enable();
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/commands/shooter/SetShooterSpeed.java
+++ b/src/main/java/frc/robot/commands/shooter/SetShooterSpeed.java
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands.shooter;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.Shooter;
+
+public class SetShooterSpeed extends CommandBase {
+  private final Shooter m_shooter;
+  private final double m_speed;
+
+  /**
+   * Creates a new SetShooterSpeed.
+   */
+  public SetShooterSpeed(Shooter shooter, double speed) {
+    m_shooter = shooter;
+    m_speed = speed;
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    m_shooter.setSetpoint(m_speed);
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}


### PR DESCRIPTION
Fix #82 

Made  a command that sets the hood angle setpoint and the shooter speed setpoint. The hood angle command should not enable the PID or require the subsystem